### PR TITLE
Update enable-a-prover.mdx

### DIFF
--- a/pages/docs/guides/enable-a-prover.mdx
+++ b/pages/docs/guides/enable-a-prover.mdx
@@ -64,7 +64,7 @@ Open the `.env` file and set the following environment variables to enable your 
 </Callout>
 
 - Set `ENABLE_PROVER` to `true`
-- Set `L1_PROVER_PRIVATE_KEY` to your L1 account private key (with balance of TTKOj on TaikoL1), we will the public key of this account in the next Steps
+- Set `L1_PROVER_PRIVATE_KEY` to your L1 account private key (with balance of TTKOj on TaikoL1), we will need the public key of this account in the next Steps
 
 ### Approve TaikoL1 as TTKOj spender
 


### PR DESCRIPTION
A small mistake in this section:

"we will the public key of this account in the next Steps" - It seems a word is missing; I think it should be "we will need the public key of this account in the next Steps".